### PR TITLE
4차 수정

### DIFF
--- a/src/main/java/soboro/soboro_web/domain/CounselingRecord.java
+++ b/src/main/java/soboro/soboro_web/domain/CounselingRecord.java
@@ -2,8 +2,23 @@ package soboro.soboro_web.domain;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import soboro.soboro_web.domain.enums.EmotionTypes;
+
+import java.time.LocalDate;
 
 @Getter
 @Setter
+@Document(collection = "counseling")
 public class CounselingRecord {
+    @Id
+    private String counselingId;
+
+    private LocalDate counselingDate;   // 상담 일시
+    private String counselingSummary;     // 상담 내역 요약본 저장
+    private String counselingFeedback;    // 상담 후 피드백 저장
+
+    public CounselingRecord() {
+    }
 }

--- a/src/main/java/soboro/soboro_web/domain/DiagnosisRecord.java
+++ b/src/main/java/soboro/soboro_web/domain/DiagnosisRecord.java
@@ -1,4 +1,25 @@
 package soboro.soboro_web.domain;
 
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import soboro.soboro_web.domain.enums.DiagnosisType;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Document(collection = "diagnosis")
 public class DiagnosisRecord {
+    @Id
+    private String diagnosisId;
+
+    // 자가진단 속성 정의
+    private LocalDate diagnosisDate;    // 자가진단 한 날짜
+    private DiagnosisType diagnosisType;   // 자가진단 종류 (우울증, 불안, 조기정신증, 조울증, 스트레스, 불면, 알코올중독, 스마트기기사용장애)
+    private String DiagnosisScore;     // 자가진단 완료 시 점수 기록
+
+    public DiagnosisRecord() {
+    }
 }

--- a/src/main/java/soboro/soboro_web/domain/EmotionScoreRecord.java
+++ b/src/main/java/soboro/soboro_web/domain/EmotionScoreRecord.java
@@ -1,4 +1,25 @@
 package soboro.soboro_web.domain;
 
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import soboro.soboro_web.domain.enums.EmotionTypes;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Document(collection = "emotion")
 public class EmotionScoreRecord {
+    @Id
+    private String emotionId;
+
+    private LocalDate emotionDate;  // 감정 점수가 기록된 날짜
+    private int phqScore;           // phq-9 점수 기록
+    private float googleScore;      // google NLP 점수 기록
+    private EmotionTypes emotionType;        // 긍정,중립,부정 상태 기록
+
+    public EmotionScoreRecord() {
+    }
 }

--- a/src/main/java/soboro/soboro_web/domain/User.java
+++ b/src/main/java/soboro/soboro_web/domain/User.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import soboro.soboro_web.domain.enums.EmotionTypes;
 
 @Getter
 @Setter
@@ -21,6 +22,8 @@ public class User {
     private int userBirth;
     private String userGender;
     private int userPhone;
+
+    private EmotionTypes emotionStatus;     // 현재 사용자의 감정 상태 (긍정, 중립, 부정)
 
     public User() {}
 }

--- a/src/main/java/soboro/soboro_web/domain/enums/DiagnosisType.java
+++ b/src/main/java/soboro/soboro_web/domain/enums/DiagnosisType.java
@@ -1,0 +1,22 @@
+package soboro.soboro_web.domain.enums;
+
+public enum DiagnosisType {
+    DEPRESSION("우울증"),
+    ANXIETY("불안"),
+    EARLY_PSYCHOSIS("조기정신증"),
+    BIPOLAR("조울증"),
+    STRESS("스트레스"),
+    INSOMNIA("불면"),
+    ALCOHOL("알코올중독"),
+    DEVICE_ADDICTION("스마트기기사용장애");
+
+    private final String description;
+
+    DiagnosisType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/soboro/soboro_web/domain/enums/EmotionTypes.java
+++ b/src/main/java/soboro/soboro_web/domain/enums/EmotionTypes.java
@@ -1,0 +1,7 @@
+package soboro.soboro_web.domain.enums;
+
+public enum EmotionTypes {
+    POSITIVE,
+    NEUTRAL,
+    NEGATIVE
+}


### PR DESCRIPTION
User, EmotionScoreRecord, DiagnosisRecord, CounselingRecord, enums 생성 및 멤버 속성 정의

- 사용자의 감정 상태 (긍정,중립,부정)을 enum 클래스로 만들어서 사용
- 해당 속성이 필요한 클래스마다 EmotionTypes 타입 객체를 사용하도록 하는 방향으로 적어둠
- MongoDB 에서 서로 다른 클래스의 키를 참조하는 방식을 발견한다면 추후에 수정 필요!

- 자가진단 종류를  enum 클래스로 만들어서 사용